### PR TITLE
add is alive and is healthy endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ npm install
 npm run start
 ```
 
+# Health Check
+
+GET `/is-alive` this endpoint returns 200 if the server is running.
+GET `/is-healthy` currently the same as `/is-alive` but will be expanded.
+
 ## Contributing
 
 Contributions are highly encouraged! We welcome everyone to participate in our codebases, issue trackers, and any other form of communication. However, we expect all contributors to adhere to our [code of conduct](./CODE_OF_CONDUCT.md) to ensure a positive and collaborative environment for all involved in the project.

--- a/src/child-process/index.ts
+++ b/src/child-process/index.ts
@@ -11,6 +11,7 @@ import Fastify, { FastifyInstance } from 'fastify'
 import fastifyRateLimit from '@fastify/rate-limit'
 import { Utils as StringUtils } from '@shardus/types'
 import { registerRoutes, validateRequestData } from '../api'
+import { healthCheckRouter } from '../routes/healthCheck'
 
 interface ClientRequestDataInterface {
   header: object
@@ -46,6 +47,7 @@ export const initHttpServer = async (worker: Worker): Promise<void> => {
     timeWindow: 10,
     allowList: ['127.0.0.1', '0.0.0.0'], // Excludes local IPs from rate limits
   })
+  await fastifyServer.register(healthCheckRouter)
 
   fastifyServer.addContentTypeParser('application/json', { parseAs: 'string' }, (req, body, done) => {
     try {

--- a/src/routes/healthCheck.ts
+++ b/src/routes/healthCheck.ts
@@ -1,0 +1,14 @@
+import { FastifyPluginCallback } from 'fastify'
+
+export const healthCheckRouter: FastifyPluginCallback = function (fastify, opts, done) {
+  fastify.get('/is-alive', (req, res) => {
+    return res.status(200).send('OK')
+  })
+
+  fastify.get('/is-healthy', (req, res) => {
+    // TODO: Add actual health check logic
+    return res.status(200).send('OK')
+  })
+  
+  done()
+}


### PR DESCRIPTION
This pull request adds two new endpoints, `/is-alive` and `/is-healthy`, to the existing API. The `/is-alive` endpoint returns a 200 status code if the server is running, while the `/is-healthy` endpoint will be expanded in the future.
- adds `/is-alive`
- adds `/is-healthy`