### PR TITLE
improvement: updated batch size cycles for data distribution to 12

### DIFF
--- a/src/distributor/rmq_data_publisher.ts
+++ b/src/distributor/rmq_data_publisher.ts
@@ -37,7 +37,7 @@ export default class RMQDataPublisher {
   private isConnClosing = false
 
   private cycleCursor = 0
-  private batchSize = 5
+  private batchSize = 12
   private cursorUpdatedAt = Date.now()
   private cycleConfirmThreshold = this.batchSize - 1
   private cursorUpdateThresholdInMillis = 60_000 // 1 minute


### PR DESCRIPTION
Batch size for distributor is updated to 12 now. It means we'll wait 11 cycles before we move checkpoint to next cycle allowing all transactions & receipts to be shared with collectors