### PR TITLE
EVM-131: Implement stopDistributionAtCycle feature to stop data distribution

### DIFF
--- a/src/Config.ts
+++ b/src/Config.ts
@@ -35,6 +35,7 @@ export interface Config {
   subscribers: [] | Subscriber[]
   distributorMode: string
   MQ_DISTRIBUTOR_SERVER_PORT: number
+  stopDistributionAtCycle: number
 }
 
 let config: Config = {
@@ -65,6 +66,7 @@ let config: Config = {
   subscribers: [],
   distributorMode: process.env.DISTRIBUTOR_MODE || distributorMode.WS.toString(),
   MQ_DISTRIBUTOR_SERVER_PORT: 6101,
+  stopDistributionAtCycle: -1, // -1 means no limit, any positive number will stop distribution at that cycle
 }
 
 export interface Subscriber {

--- a/src/api.ts
+++ b/src/api.ts
@@ -104,6 +104,12 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
       })
       return
     }
+
+    // Filter out cycles at or beyond stopDistributionAtCycle
+    if (config.stopDistributionAtCycle >= 0) {
+      cycleInfo = cycleInfo.filter((cycle: { counter: number }) => cycle.counter < config.stopDistributionAtCycle)
+    }
+
     const res = Crypto.sign({
       cycleInfo,
     })
@@ -265,6 +271,14 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
         originalTxs = await OriginalTxDB.queryOriginalTxsData(skip, limit, from, to)
       }
     }
+
+    // Filter out originalTxs at or beyond stopDistributionAtCycle
+    if (config.stopDistributionAtCycle >= 0 && Array.isArray(originalTxs)) {
+      originalTxs = (originalTxs as OriginalTxDB.OriginalTxData[]).filter(
+        (tx: OriginalTxDB.OriginalTxData) => tx.cycle < config.stopDistributionAtCycle
+      )
+    }
+
     const res = Crypto.sign({
       originalTxs,
     })
@@ -412,6 +426,14 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
         receipts = await ReceiptDB.queryReceiptsBetweenCycles(skip, limit, from, to)
       }
     }
+
+    // Filter out receipts at or beyond stopDistributionAtCycle
+    if (config.stopDistributionAtCycle >= 0 && Array.isArray(receipts)) {
+      receipts = (receipts as ReceiptDB.Receipt[]).filter(
+        (receipt: ReceiptDB.Receipt) => receipt.cycle < config.stopDistributionAtCycle
+      )
+    }
+
     const res = Crypto.sign({
       receipts,
     })
@@ -541,6 +563,14 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
       })
       return
     }
+
+    // Filter out accounts at or beyond stopDistributionAtCycle
+    if (config.stopDistributionAtCycle >= 0 && Array.isArray(accounts)) {
+      accounts = accounts.filter(
+        (account: AccountDB.AccountsCopy) => account.cycleNumber < config.stopDistributionAtCycle
+      )
+    }
+
     reply.send(res)
   })
 
@@ -675,6 +705,14 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
         error: 'not specified which account to show',
       }
     }
+
+    // Filter out transactions at or beyond stopDistributionAtCycle
+    if (config.stopDistributionAtCycle >= 0 && Array.isArray(transactions)) {
+      transactions = transactions.filter(
+        (tx: { cycleNumber: number }) => tx.cycleNumber < config.stopDistributionAtCycle
+      )
+    }
+
     reply.send(res)
   })
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -571,6 +571,30 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
       )
     }
 
+    // Create response AFTER filtering
+    if (!res) {
+      res = Crypto.sign({
+        accounts,
+      })
+    } else if (startCycle || startCycle === 0) {
+      // Recreate response with filtered accounts
+      if (page) {
+        res = Crypto.sign({
+          accounts,
+          totalAccounts,
+        })
+      } else {
+        res = Crypto.sign({
+          totalAccounts,
+        })
+      }
+    } else {
+      // Recreate response with filtered accounts for other cases
+      res = Crypto.sign({
+        accounts,
+      })
+    }
+
     reply.send(res)
   })
 
@@ -713,6 +737,32 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
       )
     }
 
+    // Create response AFTER filtering
+    if (res && res.success === false) {
+      // Keep error responses as-is
+      reply.send(res)
+      return
+    }
+
+    if (startCycle || startCycle === 0) {
+      // Recreate response with filtered transactions
+      if (page) {
+        res = Crypto.sign({
+          transactions,
+          totalTransactions,
+        })
+      } else {
+        res = Crypto.sign({
+          totalTransactions,
+        })
+      }
+    } else {
+      // Recreate response with filtered transactions for other cases
+      res = Crypto.sign({
+        transactions,
+      })
+    }
+
     reply.send(res)
   })
 
@@ -726,11 +776,34 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
       reply.send(Crypto.sign({ success: false, error: result.error }))
       return
     }
-    const totalCycles = await CycleDB.queryCyleCount()
-    const totalAccounts = await AccountDB.queryAccountCount()
-    const totalTransactions = await TransactionDB.queryTransactionCount()
-    const totalReceipts = await ReceiptDB.queryReceiptCount()
-    const totalOriginalTxs = await OriginalTxDB.queryOriginalTxDataCount()
+
+    let totalCycles
+    let totalAccounts
+    let totalTransactions
+    let totalReceipts
+    let totalOriginalTxs
+
+    // If stopDistributionAtCycle is set, only count data before the cutoff
+    if (config.stopDistributionAtCycle >= 0) {
+      // Count cycles up to (but not including) stopDistributionAtCycle
+      const cycles = await CycleDB.queryCycleRecordsBetween(0, config.stopDistributionAtCycle - 1)
+      totalCycles = cycles ? cycles.length : 0
+
+      // Count accounts, transactions, receipts, and originalTxs up to the cutoff cycle
+      totalAccounts = (await AccountDB.queryAccountCountBetweenCycles(0, config.stopDistributionAtCycle - 1)) || 0
+      totalTransactions =
+        (await TransactionDB.queryTransactionCountBetweenCycles(0, config.stopDistributionAtCycle - 1)) || 0
+      totalReceipts = (await ReceiptDB.queryReceiptCountBetweenCycles(0, config.stopDistributionAtCycle - 1)) || 0
+      totalOriginalTxs = (await OriginalTxDB.queryOriginalTxDataCount(0, config.stopDistributionAtCycle - 1)) || 0
+    } else {
+      // No limit - return all counts
+      totalCycles = (await CycleDB.queryCyleCount()) || 0
+      totalAccounts = await AccountDB.queryAccountCount()
+      totalTransactions = (await TransactionDB.queryTransactionCount()) || 0
+      totalReceipts = (await ReceiptDB.queryReceiptCount()) || 0
+      totalOriginalTxs = (await OriginalTxDB.queryOriginalTxDataCount()) || 0
+    }
+
     reply.send(
       Crypto.sign({
         totalCycles,

--- a/src/api.ts
+++ b/src/api.ts
@@ -107,7 +107,7 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
 
     // Filter out cycles at or beyond stopDistributionAtCycle
     if (config.stopDistributionAtCycle >= 0) {
-      cycleInfo = cycleInfo.filter((cycle: { counter: number }) => cycle.counter < config.stopDistributionAtCycle)
+      cycleInfo = cycleInfo.filter((cycle: { counter: number }) => cycle.counter <= config.stopDistributionAtCycle)
     }
 
     const res = Crypto.sign({
@@ -275,7 +275,7 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
     // Filter out originalTxs at or beyond stopDistributionAtCycle
     if (config.stopDistributionAtCycle >= 0 && Array.isArray(originalTxs)) {
       originalTxs = (originalTxs as OriginalTxDB.OriginalTxData[]).filter(
-        (tx: OriginalTxDB.OriginalTxData) => tx.cycle < config.stopDistributionAtCycle
+        (tx: OriginalTxDB.OriginalTxData) => tx.cycle <= config.stopDistributionAtCycle
       )
     }
 
@@ -430,7 +430,7 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
     // Filter out receipts at or beyond stopDistributionAtCycle
     if (config.stopDistributionAtCycle >= 0 && Array.isArray(receipts)) {
       receipts = (receipts as ReceiptDB.Receipt[]).filter(
-        (receipt: ReceiptDB.Receipt) => receipt.cycle < config.stopDistributionAtCycle
+        (receipt: ReceiptDB.Receipt) => receipt.cycle <= config.stopDistributionAtCycle
       )
     }
 
@@ -567,7 +567,7 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
     // Filter out accounts at or beyond stopDistributionAtCycle
     if (config.stopDistributionAtCycle >= 0 && Array.isArray(accounts)) {
       accounts = accounts.filter(
-        (account: AccountDB.AccountsCopy) => account.cycleNumber < config.stopDistributionAtCycle
+        (account: AccountDB.AccountsCopy) => account.cycleNumber <= config.stopDistributionAtCycle
       )
     }
 
@@ -733,7 +733,7 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
     // Filter out transactions at or beyond stopDistributionAtCycle
     if (config.stopDistributionAtCycle >= 0 && Array.isArray(transactions)) {
       transactions = transactions.filter(
-        (tx: { cycleNumber: number }) => tx.cycleNumber < config.stopDistributionAtCycle
+        (tx: { cycleNumber: number }) => tx.cycleNumber <= config.stopDistributionAtCycle
       )
     }
 
@@ -785,16 +785,16 @@ export function registerRoutes(server: FastifyInstance<Server, IncomingMessage, 
 
     // If stopDistributionAtCycle is set, only count data before the cutoff
     if (config.stopDistributionAtCycle >= 0) {
-      // Count cycles up to (but not including) stopDistributionAtCycle
-      const cycles = await CycleDB.queryCycleRecordsBetween(0, config.stopDistributionAtCycle - 1)
+      // Count cycles up to (and including) stopDistributionAtCycle
+      const cycles = await CycleDB.queryCycleRecordsBetween(0, config.stopDistributionAtCycle)
       totalCycles = cycles ? cycles.length : 0
 
       // Count accounts, transactions, receipts, and originalTxs up to the cutoff cycle
-      totalAccounts = (await AccountDB.queryAccountCountBetweenCycles(0, config.stopDistributionAtCycle - 1)) || 0
+      totalAccounts = (await AccountDB.queryAccountCountBetweenCycles(0, config.stopDistributionAtCycle)) || 0
       totalTransactions =
-        (await TransactionDB.queryTransactionCountBetweenCycles(0, config.stopDistributionAtCycle - 1)) || 0
-      totalReceipts = (await ReceiptDB.queryReceiptCountBetweenCycles(0, config.stopDistributionAtCycle - 1)) || 0
-      totalOriginalTxs = (await OriginalTxDB.queryOriginalTxDataCount(0, config.stopDistributionAtCycle - 1)) || 0
+        (await TransactionDB.queryTransactionCountBetweenCycles(0, config.stopDistributionAtCycle)) || 0
+      totalReceipts = (await ReceiptDB.queryReceiptCountBetweenCycles(0, config.stopDistributionAtCycle)) || 0
+      totalOriginalTxs = (await OriginalTxDB.queryOriginalTxDataCount(0, config.stopDistributionAtCycle)) || 0
     } else {
       // No limit - return all counts
       totalCycles = (await CycleDB.queryCyleCount()) || 0

--- a/src/child-process/child.ts
+++ b/src/child-process/child.ts
@@ -103,20 +103,33 @@ export const registerDataReaderListeners = (reader: DataLogReader): void => {
         receipt?: unknown
         originalTx?: unknown
       } = {}
+      let dataCycle = -1
       switch (reader.dataName) {
         case 'cycle':
           data.cycle = logData
+          dataCycle = (logData as { counter: number })?.counter
           incrementCycleCount()
           break
         case 'receipt':
           data.receipt = logData
+          dataCycle = (logData as { cycle: number })?.cycle
           incrementReceiptCount()
           break
         case 'originalTx':
           data.originalTx = logData
+          dataCycle = (logData as { cycle: number })?.cycle
           incrementOriginalTxCount()
           break
       }
+
+      // Check if distribution should stop at a specific cycle
+      if (config.stopDistributionAtCycle >= 0 && dataCycle >= config.stopDistributionAtCycle) {
+        console.log(
+          `⛔ Distribution stopped: data cycle ${dataCycle} has reached or exceeded stopDistributionAtCycle ${config.stopDistributionAtCycle}`
+        )
+        return
+      }
+
       sendDataToAllClients({
         signedData: Crypto.sign(data, config.DISTRIBUTOR_SECRET_KEY, config.DISTRIBUTOR_PUBLIC_KEY),
       })

--- a/src/child-process/child.ts
+++ b/src/child-process/child.ts
@@ -123,9 +123,9 @@ export const registerDataReaderListeners = (reader: DataLogReader): void => {
       }
 
       // Check if distribution should stop at a specific cycle
-      if (config.stopDistributionAtCycle >= 0 && dataCycle >= config.stopDistributionAtCycle) {
+      if (config.stopDistributionAtCycle >= 0 && dataCycle > config.stopDistributionAtCycle) {
         console.log(
-          `⛔ Distribution stopped: data cycle ${dataCycle} has reached or exceeded stopDistributionAtCycle ${config.stopDistributionAtCycle}`
+          `⛔ Distribution stopped: data cycle ${dataCycle} has exceeded stopDistributionAtCycle ${config.stopDistributionAtCycle}`
         )
         return
       }

--- a/src/distributor/rmq_data_publisher.ts
+++ b/src/distributor/rmq_data_publisher.ts
@@ -93,7 +93,24 @@ export default class RMQDataPublisher {
 
   private async findAndPublishEvents(): Promise<void> {
     const start = this.cycleCursor
-    const end = this.cycleCursor + this.batchSize - 1
+    let end = this.cycleCursor + this.batchSize - 1
+
+    // Early exit if we've already reached the stop cycle
+    if (config.stopDistributionAtCycle >= 0 && start >= config.stopDistributionAtCycle) {
+      console.log(
+        `⛔ RMQ: Skipping data fetch - cursor ${start} has reached stopDistributionAtCycle ${config.stopDistributionAtCycle}`
+      )
+      return
+    }
+
+    // Limit end to stopDistributionAtCycle - 1 (since we want cycles before the stop cycle)
+    if (config.stopDistributionAtCycle >= 0 && end >= config.stopDistributionAtCycle) {
+      end = config.stopDistributionAtCycle - 1
+      console.log(
+        `⛔ RMQ: Limiting query range to cycles ${start}-${end} due to stopDistributionAtCycle ${config.stopDistributionAtCycle}`
+      )
+    }
+
     const cyclesFromDB = (await queryCycleRecordsBetween(start, end)) || []
 
     if (cyclesFromDB.length == 0) {
@@ -207,6 +224,7 @@ export default class RMQDataPublisher {
 
   private async publishCycles(cycles: CycleData[]): Promise<void> {
     if (cycles.length <= 0) return
+
     const messages = []
     for (let i = 0; i < cycles.length; i++) {
       const cycle = cycles.at(i)
@@ -228,6 +246,7 @@ export default class RMQDataPublisher {
 
   private async publishTransactions(transactions: OriginalTxData[]): Promise<void> {
     if (transactions.length <= 0) return
+
     const messages = []
     for (let i = 0; i < transactions.length; i++) {
       messages.push({
@@ -245,6 +264,7 @@ export default class RMQDataPublisher {
 
   private async publishReceipts(receipts: Receipt[]): Promise<void> {
     if (receipts.length <= 0) return
+
     const messages = []
     for (let i = 0; i < receipts.length; i++) {
       messages.push({

--- a/src/distributor/rmq_data_publisher.ts
+++ b/src/distributor/rmq_data_publisher.ts
@@ -96,16 +96,16 @@ export default class RMQDataPublisher {
     let end = this.cycleCursor + this.batchSize - 1
 
     // Early exit if we've already reached the stop cycle
-    if (config.stopDistributionAtCycle >= 0 && start >= config.stopDistributionAtCycle) {
+    if (config.stopDistributionAtCycle >= 0 && start > config.stopDistributionAtCycle) {
       console.log(
-        `⛔ RMQ: Skipping data fetch - cursor ${start} has reached stopDistributionAtCycle ${config.stopDistributionAtCycle}`
+        `⛔ RMQ: Skipping data fetch - cursor ${start} has exceeded stopDistributionAtCycle ${config.stopDistributionAtCycle}`
       )
       return
     }
 
-    // Limit end to stopDistributionAtCycle - 1 (since we want cycles before the stop cycle)
-    if (config.stopDistributionAtCycle >= 0 && end >= config.stopDistributionAtCycle) {
-      end = config.stopDistributionAtCycle - 1
+    // Limit end to stopDistributionAtCycle (since we want cycles up to and including the stop cycle)
+    if (config.stopDistributionAtCycle >= 0 && end > config.stopDistributionAtCycle) {
+      end = config.stopDistributionAtCycle
       console.log(
         `⛔ RMQ: Limiting query range to cycles ${start}-${end} due to stopDistributionAtCycle ${config.stopDistributionAtCycle}`
       )

--- a/src/log-reader/index.ts
+++ b/src/log-reader/index.ts
@@ -163,6 +163,30 @@ class DataLogReader extends EventEmitter {
                 clearInterval(fileStreamer)
               } else {
                 const parse = StringUtils.safeJsonParse(data)
+
+                // Check if we should stop reading based on cycle cutoff
+                if (config.stopDistributionAtCycle >= 0) {
+                  let dataCycle = -1
+                  if (this.dataName === 'cycle' && parse?.counter !== undefined) {
+                    dataCycle = parse.counter
+                  } else if (
+                    (this.dataName === 'receipt' || this.dataName === 'originalTx') &&
+                    parse?.cycle !== undefined
+                  ) {
+                    dataCycle = parse.cycle
+                  }
+
+                  if (dataCycle >= config.stopDistributionAtCycle) {
+                    console.log(
+                      `⛔ Log Reader: Stopping ${this.dataName} log reading - reached stopDistributionAtCycle ${config.stopDistributionAtCycle}`
+                    )
+                    clearInterval(fileStreamer)
+                    rl.close()
+                    stream.close()
+                    return
+                  }
+                }
+
                 totalNumberOfEntries += 1
                 /* prettier-ignore */ if (config.VERBOSE) console.log(`${this.dataName}-data`, data)
                 this.emit(`${this.dataName}-data`, parse)

--- a/src/log-reader/index.ts
+++ b/src/log-reader/index.ts
@@ -176,9 +176,9 @@ class DataLogReader extends EventEmitter {
                     dataCycle = parse.cycle
                   }
 
-                  if (dataCycle >= config.stopDistributionAtCycle) {
+                  if (dataCycle > config.stopDistributionAtCycle) {
                     console.log(
-                      `⛔ Log Reader: Stopping ${this.dataName} log reading - reached stopDistributionAtCycle ${config.stopDistributionAtCycle}`
+                      `⛔ Log Reader: Stopping ${this.dataName} log reading - exceeded stopDistributionAtCycle ${config.stopDistributionAtCycle}`
                     )
                     clearInterval(fileStreamer)
                     rl.close()


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Introduced `stopDistributionAtCycle` config to control data distribution cutoff

- Enforced cycle cutoff in API endpoints, log reader, and data publisher

- Added filtering logic to prevent serving or distributing data at or beyond cutoff

- Updated multiple components for consistent cutoff enforcement


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Config.ts</strong><dd><code>Add stopDistributionAtCycle to configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Config.ts

<li>Added <code>stopDistributionAtCycle</code> to the config interface and default <br>config<br> <li> Documented its usage and default value


</details>


  </td>
  <td><a href="https://github.com/shardeum/distributor/pull/52/files#diff-b83e1482492860acb73eb6a72535d0dd31b4fc971525ff13c35fb97222172d39">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>api.ts</strong><dd><code>Enforce stopDistributionAtCycle cutoff in API endpoints</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/api.ts

<li>Added filtering in API endpoints to exclude data at or beyond <br>stopDistributionAtCycle<br> <li> Applied cutoff logic to cycles, transactions, receipts, and accounts <br>endpoints


</details>


  </td>
  <td><a href="https://github.com/shardeum/distributor/pull/52/files#diff-769911c416ccf8514d8fd941ae0abe8fb5c606ade0c218e22151a5f5f9f3d700">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>child.ts</strong><dd><code>Block data distribution at or beyond stopDistributionAtCycle</code></dd></summary>
<hr>

src/child-process/child.ts

<li>Checked data cycle against stopDistributionAtCycle before sending to <br>clients<br> <li> Prevented distribution if cycle cutoff is reached


</details>


  </td>
  <td><a href="https://github.com/shardeum/distributor/pull/52/files#diff-dbce0ff027885fbddd026d1f80dfed022d660b19494c46bff9b48a53a9610c77">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rmq_data_publisher.ts</strong><dd><code>Enforce stopDistributionAtCycle in RMQ data publishing</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/distributor/rmq_data_publisher.ts

<li>Added logic to skip or limit publishing if stopDistributionAtCycle is <br>reached<br> <li> Adjusted query range and logging for cutoff enforcement


</details>


  </td>
  <td><a href="https://github.com/shardeum/distributor/pull/52/files#diff-b23b3be4cc6195c1ddd232e6723ecb8b561509f447f9b29e9e64b26972a1ec00">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Stop log reading at stopDistributionAtCycle cutoff</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/log-reader/index.ts

<li>Stopped log reading when stopDistributionAtCycle is reached<br> <li> Closed streams and emitted logs for cutoff event


</details>


  </td>
  <td><a href="https://github.com/shardeum/distributor/pull/52/files#diff-793b30017570dfbabb17245586fc95ef2939dc61ce35f78f078ac34a9b091d24">+24/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>